### PR TITLE
Removes some hardcoded region values

### DIFF
--- a/BIOps_Deployment_Scripts/cdk/cdk/quicksight_embed_stack.py
+++ b/BIOps_Deployment_Scripts/cdk/cdk/quicksight_embed_stack.py
@@ -79,7 +79,7 @@ class QuicksightEmbedStack(core.Stack):
             memory_size=512,
             environment={
                 'DASHBOARD_ID': 'CHANGEME_DASHBOARD_ID',
-                'QUICKSIGHT_USER_ARN': f'arn:aws:quicksight:us-east-1:{core.Aws.ACCOUNT_ID}:user/default/quicksight-migration-user'
+                'QUICKSIGHT_USER_ARN': f'arn:aws:quicksight:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:user/default/quicksight-migration-user'
             }
         )
 

--- a/BIOps_Deployment_Scripts/cdk/lambda/quicksight_embed/quicksight_embed.py
+++ b/BIOps_Deployment_Scripts/cdk/lambda/quicksight_embed/quicksight_embed.py
@@ -38,7 +38,7 @@ def lambda_handler(event, context):
     quicksight_user_arn = os.getenv('QUICKSIGHT_USER_ARN')
 
     try:
-        qs_client = boto3.client('quicksight', region_name='us-east-1', config=default_botocore_config())
+        qs_client = boto3.client('quicksight', config=default_botocore_config())
 
         response = qs_client.get_dashboard_embed_url(
             AwsAccountId=account_id,

--- a/BIOps_Deployment_Scripts/cdk/lambda/quicksight_migration/quicksight_migration/lambda_function.py
+++ b/BIOps_Deployment_Scripts/cdk/lambda/quicksight_migration/quicksight_migration/lambda_function.py
@@ -82,7 +82,7 @@ def lambda_handler(event, context):
                                             source_region)
     target_session = qs_utils.assume_role(target_account_id, target_role_name,
                                             target_region)
-    target_admin = qs_utils.get_user_arn(target_session, 'quicksight-migration-user')
+    target_admin = qs_utils.get_user_arn(target_session, 'quicksight-migration-user', target_region)
     infra_details = qs_utils.get_ssm_parameters(target_session, infra_config_param_name)
 
     # QuickSight VPC connection will use VPC ID as name

--- a/BIOps_Deployment_Scripts/cdk/lambda/quicksight_migration/quicksight_migration/quicksight_utils.py
+++ b/BIOps_Deployment_Scripts/cdk/lambda/quicksight_migration/quicksight_migration/quicksight_utils.py
@@ -84,7 +84,7 @@ def get_secret(session, secret_name):
             decoded_binary_secret = base64.b64decode(get_secret_value_response['SecretBinary'])
             return decoded_binary_secret
 
-def get_user_arn(session, username, region='us-east-1', namespace='default'):
+def get_user_arn(session, username, region, namespace='default'):
     sts_client = session.client("sts")
     account_id = sts_client.get_caller_identity()["Account"]
     if username == 'root':
@@ -95,7 +95,7 @@ def get_user_arn(session, username, region='us-east-1', namespace='default'):
 
 def get_target(
     targetsession, rds, redshift, s3Bucket, s3Key, vpc, tag, targetadmin,
-    rdscredential,redshiftcredential, region='us-east-1', namespace='default',
+    rdscredential,redshiftcredential, region, namespace='default',
     version='1'):
     sts_client = targetsession.client("sts")
     account_id = sts_client.get_caller_identity()["Account"]

--- a/BIOps_Deployment_Scripts/cdk/lambda/quicksight_status/quicksight_status.py
+++ b/BIOps_Deployment_Scripts/cdk/lambda/quicksight_status/quicksight_status.py
@@ -27,13 +27,12 @@ def default_botocore_config() -> botocore.config.Config:
 
 sts_client = boto3.client("sts", config=default_botocore_config())
 account_id = sts_client.get_caller_identity()["Account"]
-aws_region = 'us-east-1'
-lambda_aws_region = os.environ['AWS_REGION']
+aws_region = os.environ['AWS_REGION']
 qs_client = boto3.client('quicksight', config=default_botocore_config())
-qs_local_client = boto3.client('quicksight', region_name=lambda_aws_region, config=default_botocore_config())
+qs_local_client = boto3.client('quicksight', config=default_botocore_config())
 
 def lambda_handler(event, context):
-    sts_client = boto3.client("sts", region_name=aws_region, config=default_botocore_config())
+    sts_client = boto3.client("sts", config=default_botocore_config())
     account_id = sts_client.get_caller_identity()["Account"]
 
     # call s3 bucket
@@ -70,12 +69,12 @@ def lambda_handler(event, context):
     bucket.upload_file(path, key)
 
     path = os.path.join(tmpdir, local_file_name2)
-    dashboards = list_dashboards(account_id, lambda_aws_region)
+    dashboards = list_dashboards(account_id, aws_region)
 
     for dashboard in dashboards:
         dashboardid = dashboard['DashboardId']
 
-        response = describe_dashboard_permissions(account_id, dashboardid, lambda_aws_region)
+        response = describe_dashboard_permissions(account_id, dashboardid, aws_region)
         permissions = response['Permissions']
         for principal in permissions:
             actions = '|'.join(principal['Actions'])
@@ -85,17 +84,17 @@ def lambda_handler(event, context):
             additional_info = principal[-2]
             principal = principal[-1]
 
-            access.append([account_id, lambda_aws_region, 'dashboard', dashboard['Name'],
-                            dashboardid, ptype, principal, additional_info, actions])
+            access.append([account_id, aws_region, 'dashboard', dashboard['Name'],
+                           dashboardid, ptype, principal, additional_info, actions])
 
-    datasets = list_datasets(account_id, lambda_aws_region)
+    datasets = list_datasets(account_id, aws_region)
 
     for dataset in datasets:
         if dataset['Name'] not in ['Business Review', 'People Overview', 'Sales Pipeline',
                                    'Web and Social Media Analytics']:
             datasetid = dataset['DataSetId']
 
-            response = describe_data_set_permissions(account_id, datasetid, lambda_aws_region)
+            response = describe_data_set_permissions(account_id, datasetid, aws_region)
             permissions = response['Permissions']
             for principal in permissions:
                 actions = '|'.join(principal['Actions'])
@@ -105,10 +104,10 @@ def lambda_handler(event, context):
                 additional_info = principal[-2]
                 principal = principal[-1]
 
-                access.append([account_id, lambda_aws_region, 'dataset', dataset['Name'],
-                                datasetid, ptype, principal, additional_info, actions])
+                access.append([account_id, aws_region, 'dataset', dataset['Name'],
+                               datasetid, ptype, principal, additional_info, actions])
 
-    datasources = list_datasources(account_id, lambda_aws_region)
+    datasources = list_datasources(account_id, aws_region)
 
     for datasource in datasources:
         if datasource['Name'] not in ['Business Review', 'People Overview', 'Sales Pipeline',
@@ -117,7 +116,7 @@ def lambda_handler(event, context):
             if 'DataSourceParameters' in datasource:
                 try:
                     response = describe_data_source_permissions(account_id, datasourceid,
-                                                                lambda_aws_region)
+                                                                aws_region)
                     permissions = response['Permissions']
                     for principal in permissions:
                         actions = '|'.join(principal['Actions'])
@@ -127,19 +126,19 @@ def lambda_handler(event, context):
                         additional_info = principal[-2]
                         principal = principal[-1]
 
-                        access.append([account_id, lambda_aws_region, 'data_source',
-                                        datasource['Name'], datasourceid, ptype, principal,
-                                        additional_info, actions])
+                        access.append([account_id, aws_region, 'data_source',
+                                       datasource['Name'], datasourceid, ptype, principal,
+                                       additional_info, actions])
                 except Exception as e:
                     pass
 
-    analyses = list_analyses(account_id, lambda_aws_region)
+    analyses = list_analyses(account_id, aws_region)
 
     for analysis in analyses:
         if analysis['Status'] != 'DELETED':
             analysisid = analysis['AnalysisId']
 
-            response = describe_analysis_permissions(account_id, analysisid, lambda_aws_region)
+            response = describe_analysis_permissions(account_id, analysisid, aws_region)
             permissions = response['Permissions']
             for principal in permissions:
                 actions = '|'.join(principal['Actions'])
@@ -149,14 +148,14 @@ def lambda_handler(event, context):
                 additional_info = principal[-2]
                 principal = principal[-1]
 
-                access.append([account_id, lambda_aws_region, 'analysis', analysis['Name'],
-                                analysisid, ptype, principal, additional_info, actions])
+                access.append([account_id, aws_region, 'analysis', analysis['Name'],
+                               analysisid, ptype, principal, additional_info, actions])
 
-    themes = list_themes(account_id, lambda_aws_region)
+    themes = list_themes(account_id, aws_region)
     for theme in themes:
         if theme['ThemeId'] not in ['SEASIDE', 'CLASSIC', 'MIDNIGHT']:
             themeid = theme['ThemeId']
-            response = describe_theme_permissions(account_id, themeid, lambda_aws_region)
+            response = describe_theme_permissions(account_id, themeid, aws_region)
             permissions = response['Permissions']
             for principal in permissions:
                 actions = '|'.join(principal['Actions'])
@@ -165,8 +164,8 @@ def lambda_handler(event, context):
                 ptype = ptype[-1]
                 additional_info = principal[-2]
                 principal = principal[-1]
-                access.append([account_id, lambda_aws_region, 'theme', theme['Name'],
-                                themeid, ptype, principal, additional_info, actions])
+                access.append([account_id, aws_region, 'theme', theme['Name'],
+                               themeid, ptype, principal, additional_info, actions])
 
     with open(path, 'w', newline='') as outfile:
         writer = csv.writer(outfile)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hi,
I created this PR that removes some hard-coded region code names in the code and methods as this breaks when this is deployed in a region different to "us-east-1".

I haven't deeply tested the modifications but just tried to move away of the hard-coded value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
